### PR TITLE
chore(deps): Remove unneeded `child_process` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "unittest": "mkdir -p \"report/tests\" && env BABEL_ENV='test' XUNIT_FILE='report/tests/TESTS-NodeJS.xml' node node_modules/mocha/bin/mocha --ui bdd --recursive 'unittest/*.spec.js' -R spec-xunit-file",
     "test": "npm run unittest && npm run integration-test"
   },
-  "dependencies": {
-    "child_process": "1.0.2"
-  },
   "devDependencies": {
     "browserify": "16.2.3",
     "chai": "4.2.0",


### PR DESCRIPTION
The [`child_process`](https://www.npmjs.com/package/child_process) package on **npm** is a security holding stub package.

The `child_process` that is actually `require(…)`d is a built‑in **Node** module.